### PR TITLE
Guard the FP operation with 'kernel_fpu_begin' and 'kernel_fpu_end'

### DIFF
--- a/tcp_evil.c
+++ b/tcp_evil.c
@@ -15,6 +15,7 @@
 
 #include <linux/module.h>
 #include <net/tcp.h>
+#include <asm/i387.h>
 
 /* Tcp evil structure. */
 struct evil {
@@ -169,7 +170,11 @@ static void evil_cong_avoid(struct sock *sk, u32 ack, u32 in_flight)
 u32 evil_ssthresh(struct sock *sk)
 {
 	const struct tcp_sock *tp = tcp_sk(sk);
-	return max(tp->snd_cwnd * 0.9, 2U);
+	u32 ret;
+	kernel_fpu_begin();
+	ret = max_t(u32, tp->snd_cwnd * 0.9, 2U);
+	kernel_fpu_end();
+	return ret;
 }
 EXPORT_SYMBOL_GPL(evil_ssthresh);
 


### PR DESCRIPTION
Per the comments in  https://github.com/clowwindy/tcp_evil/pull/2.

References:
https://stackoverflow.com/questions/13886338/use-of-floating-point-in-the-linux-kernel
http://yarchive.net/comp/linux/kernel_fp.html